### PR TITLE
Add result transformers, option to set default consistency on driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ var db = require("priam")({
                 cqlVersion: "3.0.0", /* optional, defaults to "3.0.0" */
                 timeout: 4000, /* optional, defaults to 4000 */
                 poolSize: 2, /* optional, defaults to 1 */
-                consistencyLevel: 1, /* optional, defaults to 1. Should be a valid db.consistencyLevel value */
+                consistencyLevel: "one", /* optional, defaults to one. Will throw if not a valid Cassandra consistency level*/
                 driver: "helenus", /* optional, defaults to "node-cassandra-cql" */,
                 numRetries: 3, /* optional, defaults to 0. Retries occur on connection failures. */
                 retryDelay: 100, /* optional, defaults to 100ms. Used on error retry or consistency fallback retry */
@@ -528,6 +528,10 @@ var db = require("priam")({
 
 Release Notes
 -------------
+ - `0.8.5`: Changed config to look up consistency level enum if given a string
+            Added resultTransformers to drivers and queries-- synchronous functions that are mapped over query results
+            Query consistency is set to driver's at instantiation, rather than being looked up at execution if not present
+            Added `query` method to base driver, alias for `cql`
  - `0.8.4`: Modified `Batch.execute()` to send timestamps as parameters instead of CQL strings.
  - `0.8.3`: Added `Query.single()`, `Query.first()`, and `Query.all()` enhancements.
  - `0.8.2`: Added generalized `Batch.add()` that can take a `Query` or `Batch` argument.

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -9,6 +9,6 @@ function Driver(context) {
   }
 }
 
-exports = module.exports = function (context) {
+module.exports = function (context) {
   return Driver(context);
 };

--- a/lib/drivers/base-driver.js
+++ b/lib/drivers/base-driver.js
@@ -49,6 +49,15 @@ BaseDriver.prototype.init = function init(context) {
     consistencyLevel: this.consistencyLevel.one
   };
   this.poolConfig = _.extend(this.poolConfig, this.config);
+  if( typeof this.config.consistency === 'string' ) {
+    var level = this.config.consistency;
+
+    if (typeof this.consistencyLevel[level] !== "undefined") {
+      this.poolConfig.consistencyLevel = this.consistencyLevel[level];
+    } else {
+      throw new Error('Error: "' + level + '" is not a valid consistency level');
+    }
+  }
 
   this.connectionResolver = null;
   if (context.connectionResolver) {
@@ -71,6 +80,8 @@ BaseDriver.prototype.init = function init(context) {
   this.pools = {};
 
   this.ConnectionPool = helenus.ConnectionPool;
+
+  this.resultTransformers = context.resultTransformers || [];
 };
 
 BaseDriver.prototype.remapConnectionOptions = function remapConnectionOptions(connectionData) {
@@ -336,10 +347,17 @@ BaseDriver.prototype.cql = function executeCqlQuery(cqlQuery, dataParams, option
       metrics.measurement('query.' + options.queryName, duration, 'ms');
     }
     if (typeof callback === "function") {
+      if(options && options.resultTransformers && options.resultTransformers.length){
+        for(var i = 0; i < options.resultTransformers.length; i++){
+          result = result.map(options.resultTransformers[i]);
+        }
+      }
       callback(err, result);
     }
   });
 };
+
+BaseDriver.prototype.query = BaseDriver.prototype.cql;
 
 BaseDriver.prototype.select = function select(cql, dataParams, options, callback) {
   var params = setDefaultConsistency(this.consistencyLevel.ONE, options, callback);
@@ -359,7 +377,12 @@ BaseDriver.prototype.delete = function deleteQuery(cql, dataParams, options, cal
 };
 
 BaseDriver.prototype.beginQuery = function beginQuery() {
-  return new Query(this);
+  var self = this;
+  var querySettings = {
+    options: {consistency: self.poolConfig.consistencyLevel},
+    resultTransformers: self.resultTransformers
+  };
+  return new Query(this, querySettings);
 };
 
 BaseDriver.prototype.beginBatch = function beginBatch() {

--- a/lib/drivers/helenus.js
+++ b/lib/drivers/helenus.js
@@ -37,7 +37,7 @@ function HelenusDriver() {
 }
 util.inherits(HelenusDriver, BaseDriver);
 
-exports = module.exports = function (context) {
+module.exports = function (context) {
   var driver = new HelenusDriver();
   driver.init(context);
   return driver;

--- a/lib/drivers/node-cassandra-cql.js
+++ b/lib/drivers/node-cassandra-cql.js
@@ -34,7 +34,7 @@ function NodeCassandraDriver() {
 }
 util.inherits(NodeCassandraDriver, BaseDriver);
 
-exports = module.exports = function (context) {
+module.exports = function (context) {
   var driver = new NodeCassandraDriver();
   driver.init(context);
   return driver;

--- a/lib/util/batch.js
+++ b/lib/util/batch.js
@@ -264,4 +264,4 @@ function containsBatch(parentBatch, batchToFind) {
   });
 }
 
-exports = module.exports = Batch;
+module.exports = Batch;

--- a/lib/util/query.js
+++ b/lib/util/query.js
@@ -3,20 +3,21 @@
 var _ = require("lodash"),
   promisify = require("./promisify");
 
-function Query(db) {
+function Query(db, context) {
   if (!db) {
     throw new Error("'db' parameter is required");
   }
 
   this.db = db;
-  this.context = {
+  this.context = _.assign({}, {
     cql: null,
     params: [],
     options: {},
     errors: [],
     single: false,
-    first: false
-  };
+    first: false,
+    resultTransformers: []
+  }, context);
 }
 
 Query.prototype.single = function single() {
@@ -100,6 +101,16 @@ Query.prototype.execute = function execute(callback) {
   return void executeQuery.call(this, callback);
 };
 
+Query.prototype.addResultTransformer = function addResultTransformer(fn){
+  this.context.resultTransformers.push(fn);
+  return this;
+};
+
+Query.prototype.clearResultTransformers = function clearResultTransformers(){
+  this.context.resultTransformers = [];
+  return this;
+};
+
 function yieldErrors(errors, callback) {
   if (errors.length === 1) {
     return void callback(errors[0]);
@@ -144,4 +155,4 @@ function addIfNotExists(dictionary, key, value) {
   }
 }
 
-exports = module.exports = Query;
+module.exports = Query;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "priam",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "A simple Cassandra driver. It wraps the helenus and node-cassandra-cql drivers with additional error/retry handling, external .cql file support, and connection option resolution from an external source, among other improvements.",
   "keywords": [
     "cassandra",

--- a/test/unit/drivers/base-driver.tests.js
+++ b/test/unit/drivers/base-driver.tests.js
@@ -32,10 +32,12 @@ describe("lib/drivers/base-driver.js", function () {
   }
 
   function getDefaultInstance() {
-    var instance = new Driver({
+    var instance = new Driver();
+    var context = {
       config: getDefaultConfig(),
       logger: getDefaultLogger()
-    });
+    };
+    instance.init(context);
     return instance;
   }
 
@@ -92,6 +94,30 @@ describe("lib/drivers/base-driver.js", function () {
       // assert
       assert.ok(instance.consistencyLevel);
       assert.ok(instance.dataType);
+    });
+
+    it("converts consistency levels to DB codes", function () {
+      // arrange
+      // act
+      var instance = new Driver();
+      instance.consistencyLevel = {one: 1};
+      instance.init({config: {consistency: 'one'}});
+
+      // assert
+      assert.equal(instance.consistencyLevel.one, instance.poolConfig.consistencyLevel);
+    });
+
+    it("throws an error if given an invalid consistency level", function () {
+      // arrange
+      // act
+      var instance = new Driver();
+      instance.consistencyLevel = {one: 1};
+      var initWithInvalidConsistency = function() {
+        instance.init({config: {consistency: 'invalid consistency level'}});
+      };
+
+      // assert
+      assert.throw(initWithInvalidConsistency, 'Error: "invalid consistency level" is not a valid consistency level' );
     });
   });
 

--- a/test/unit/util/query.tests.js
+++ b/test/unit/util/query.tests.js
@@ -28,7 +28,7 @@ describe("lib/util/query.js", function () {
     query = new Query(db);
   });
 
-  describe("interface", function () {
+  describe("constructor", function () {
 
     it("is a constructor function", function () {
       assert.strictEqual(typeof Query, "function", "is a constructor function");
@@ -42,6 +42,32 @@ describe("lib/util/query.js", function () {
 
       done();
     });
+
+    it("creates a resultTransformer array in context", function (done) {
+      // arrange
+      query = new Query(db);
+
+      // assert
+      assert.deepEqual(query.context.resultTransformers, [], "resultTransformers created");
+      done();
+    });
+
+    it("applies provided settings to its context", function () {
+      // arrange
+      var resultTransformer = function(obj){return obj;};
+
+      // act
+      query = new Query(db, {
+        resultTransformers: [resultTransformer],
+        options: {consistency: 1}
+      });
+
+      // assert
+      assert.strictEqual(query.context.resultTransformers.length, 1, "resultTransformer added");
+      assert.strictEqual(typeof query.context.resultTransformers[0], "function", "resultTransformer is a function");
+      assert.strictEqual(query.context.options.consistency, 1, "options set");
+    });
+
   });
 
   describe("constructed instance", function () {
@@ -91,6 +117,15 @@ describe("lib/util/query.js", function () {
     it("provides a single function", function () {
       validateFunctionExists("single", 0);
     });
+
+    it("provides an addResultTransformer function", function () {
+      validateFunctionExists("addResultTransformer", 1);
+    });
+
+    it("provides a clearResultTransformers function", function () {
+      validateFunctionExists("clearResultTransformers", 0);
+    });
+
 
   });
 
@@ -683,6 +718,35 @@ describe("lib/util/query.js", function () {
 
     it("returns self", function () {
       var result = query.single();
+      assert.equal(result, query, "returns self");
+    });
+  });
+
+  describe("#addResultTransformer()", function(){
+    it("adds a transformer to the context", function(){
+      var transformer = function(obj){return obj;};
+      query.addResultTransformer(transformer);
+      assert.strictEqual(query.context.resultTransformers.length, 1, "resultTransformer added");
+      assert.strictEqual(typeof query.context.resultTransformers[0], "function", "resultTransformer is a function");
+    });
+
+    it("returns self", function () {
+      var result = query.addResultTransformer();
+      assert.equal(result, query, "returns self");
+    });
+  });
+
+  describe("#clearResultTransformers()", function(){
+    it("removes transformers from the context", function(){
+      var transformer = function(obj){return obj;};
+      query.addResultTransformer(transformer);
+      query.addResultTransformer(transformer);
+      query.clearResultTransformers();
+      assert.strictEqual(query.context.resultTransformers.length, 0, "resultTransformer removed");
+    });
+
+    it("returns self", function () {
+      var result = query.clearResultTransformers();
       assert.equal(result, query, "returns self");
     });
   });


### PR DESCRIPTION
Result transformers are an array of synchronous functions which are mapped over the result of a query before results are transformed. These are useful for formatting changes, like converting snake to camel case, or other global formatting policies.

Result transformers can be passed into the driver at initialization, or can be applied to individual queries.
