### PR TITLE
Add better Cassandra version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ By default, the driver uses [node-cassandra-cql](https://github.com/jorgebay/nod
 If a Thrift connection is desired, simply specify the [helenus](https://github.com/simplereach/helenus) driver option
 in config. [Priam](https://github.com/godaddy/node-priam) uses internal aliases to map
 [helenus](https://github.com/simplereach/helenus) and [node-cassandra-cql](https://github.com/jorgebay/node-cassandra-cql)
-options to facilitate easily switching between the two drivers.
+options to facilitate easily switching between the two drivers. Specifying the appropriate `cqlVersion` for your database
+will ensure that the appropriate driver is selected.
 
 [Priam](https://github.com/godaddy/node-priam) is designed to be used as a single instance in order to preserve the
 connection pools. As an example, in an [Express](http://expressjs.com/) application,
@@ -186,7 +187,7 @@ Calling `#beginQuery()` returns a `Query` object with the following chainable fu
  - `#single()`: Similar to first, will return first result however will yield an error if more than one record found.
 
  - `#execute(callback [optional, function])`: Executes the query. If a callback is not supplied, this will return a Promise.
- 
+
 
 
 #### Fluent Syntax Examples ####
@@ -271,7 +272,7 @@ Calling `#beginBatch()` returns a `Query` object with the following chainable fu
     should be created by `db.beginBatch()`.
 
  - `#add(batchOrQuery [Batch or Query])`: Allows `null`, `Query`, or `Batch` objects. See `#addQuery()` and `#addBatch()`
-    above. 
+    above.
 
  - `#options(optionsDictionary [object])`: Extends the batch. See
     [Executing CQL](https://github.com/godaddy/node-priam/blob/master/README.md#executing-cql) for valid options.
@@ -536,9 +537,10 @@ var db = require('priam')({
 
 Release Notes
 -------------
+ - `0.8.12`: Remove github dependency via `priam-connection-cql` module. Added versioning logic around `cqlVersion` to use the appropriate driver.
  - `0.8.11`: Coerce `timestamp` hinted parameters for `node-cassandra-cql` to `Date` objects from `string` or `number`.
  - `0.8.10`: `Batch.add()` can now take an `Array` argument.
- - `0.8.9`: Fix usage of `Batch.addBatch()` in pre-2.0 Cassandra environments that do not support DML-level timestamps.  
+ - `0.8.9`: Fix usage of `Batch.addBatch()` in pre-2.0 Cassandra environments that do not support DML-level timestamps.
  - `0.8.8`: Fixed bug where `Query.single()` and `Query.first()` would return empty array instead of null on empty result sets.
  - `0.8.7`: Fixed bug which caused boolean values to not be returned when their value is false
  - `0.8.6`: Fixed bug which caused resultTransformers to not execute

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1,10 +1,32 @@
 'use strict';
 
+var parseVersion = require('./util/parse-version');
+
 function Driver(context) {
-  if (context && context.config && (context.config.driver === 'helenus' || context.config.driver === 'thrift')) {
+
+  context = context || {};
+  context.config = context.config || {};
+  context.config.version = context.config.cqlVersion = context.config.cqlVersion || context.config.version || '3.1.0';
+  var version = context.config.parsedCqlVersion = parseVersion(context.config.cqlVersion);
+  var driver = context.config.driver || 'node-cassandra-cql';
+
+  var protocol = 'binaryV2';
+  if (driver === 'helenus' || driver === 'thrift' || version.major < 3) {
+    // thrift is only supported by Helenus driver, and binary is not supported until Cassandra 1.2 (CQL3)
+    protocol = 'thrift';
+  }
+  else if (version.major < 3 || (version.major === 3 && version.minor < 1)) {
+    // binaryV2 protocol supported in latest node-cassandra-cql did not exist until Cassandra 2.0 (CQL3.1)
+    protocol = 'binaryV1';
+  }
+  context.config.protocol = protocol;
+
+  if (protocol === 'thrift') {
+    context.config.driver = 'helenus';
     return new (require('./drivers/helenus'))(context);
   }
   else {
+    context.config.driver = (protocol === 'binaryV2' ? 'node-cassandra-cql' : 'priam-cassandra-cql');
     return new (require('./drivers/node-cassandra-cql'))(context);
   }
 }

--- a/lib/drivers/base-driver.js
+++ b/lib/drivers/base-driver.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var EventEmitter = require('events').EventEmitter
-  , helenus = require('helenus')
   , util = require('util')
   , async = require('async')
   , QueryCache = require('./../util/query-cache')
@@ -77,9 +76,6 @@ BaseDriver.prototype.init = function init(context) {
   }
 
   this.pools = {};
-
-  this.ConnectionPool = helenus.ConnectionPool;
-
   this.resultTransformers = context.resultTransformers || [];
 };
 
@@ -108,7 +104,7 @@ BaseDriver.prototype.getConnectionPool = function getConnectionPool(keyspace, wa
     if (keyspace) {
       config = _.extend(config, { keyspace: keyspace });
     }
-    
+
     var pool = self.pools[keyspaceKey];
     if (!pool && self.pools.default && self.pools.default.storeConfig.keyspace === keyspace) {
       pool = self.pools.default;

--- a/lib/drivers/helenus.js
+++ b/lib/drivers/helenus.js
@@ -14,6 +14,7 @@ var helenus = require('helenus')
 
 function HelenusDriver() {
   BaseDriver.call(this);
+  this.cqlDriver = helenus;
   this.consistencyLevel = {
     ONE: consistencies.ONE,
     one: consistencies.ONE,
@@ -46,7 +47,6 @@ module.exports.HelenusDriver = HelenusDriver;
 HelenusDriver.prototype.initProviderOptions = function init(config) {
   this.ConnectionPool = helenus.ConnectionPool;
   config.supportsPreparedStatements = false;
-  config.cqlVersion = config.cqlVersion || '3.0.0';
 };
 
 HelenusDriver.prototype.createConnectionPool = function createConnectionPool(poolConfig, waitForConnect, callback) {

--- a/lib/drivers/node-cassandra-cql.js
+++ b/lib/drivers/node-cassandra-cql.js
@@ -1,16 +1,16 @@
 'use strict';
 
-var cql = require('node-cassandra-cql')
-  , _ = require('lodash')
+var _ = require('lodash')
   , util = require('util')
   , uuid = require('uuid')
   , BaseDriver = require('./base-driver')
-  , retryErrors = ['DriverError', 'PoolConnectionError', 'ECONNRESET', 'ENOTFOUND', 'ECONNREFUSED']
-  , consistencies = cql.types.consistencies
-  , dataTypes = cql.types.dataTypes;
+  , retryErrors = ['DriverError', 'PoolConnectionError', 'ECONNRESET', 'ENOTFOUND', 'ECONNREFUSED'];
 
-function NodeCassandraDriver() {
+function NodeCassandraDriver(cqlDriver) {
   BaseDriver.call(this);
+  this.cqlDriver = cqlDriver;
+  this.dataType = _.extend(this.dataType, cqlDriver.types.dataTypes);
+  var consistencies = cqlDriver.types.consistencies;
   this.consistencyLevel = {
     ONE: consistencies.one,
     one: consistencies.one,
@@ -29,12 +29,12 @@ function NodeCassandraDriver() {
     ANY: consistencies.any,
     any: consistencies.any
   };
-  this.dataType = _.extend(this.dataType, dataTypes);
 }
 util.inherits(NodeCassandraDriver, BaseDriver);
 
 module.exports = function (context) {
-  var driver = new NodeCassandraDriver();
+  var cqlDriver = require((context && context.config && context.config.driver) || 'node-cassandra-cql');
+  var driver = new NodeCassandraDriver(cqlDriver);
   driver.init(context);
   return driver;
 };
@@ -43,7 +43,6 @@ module.exports.NodeCassandraDriver = NodeCassandraDriver;
 NodeCassandraDriver.prototype.initProviderOptions = function init(config) {
   setHelenusOptions(config);
   config.supportsPreparedStatements = true;
-  config.version = config.version || '3.0.0';
 };
 
 NodeCassandraDriver.prototype.createConnectionPool = function createConnectionPool(poolConfig, waitForConnect, callback) {
@@ -58,7 +57,7 @@ NodeCassandraDriver.prototype.createConnectionPool = function createConnectionPo
     }
   });
 
-  pool = new cql.Client(poolConfig);
+  pool = new self.cqlDriver.Client(poolConfig);
   pool.storeConfig = poolConfig;
   pool.waiters = [];
   pool.isReady = false;
@@ -163,7 +162,7 @@ NodeCassandraDriver.prototype.dataToCql = function dataToCql(val) {
   if (val && val.hasOwnProperty('value') && val.hasOwnProperty('hint')) {
 
     // Transform timestamp values into Date objects if number or string
-    if (val.hint === dataTypes.timestamp) {
+    if (val.hint === this.dataType.timestamp) {
       if (typeof val.value === 'number') {
         val.value = new Date(val.value);
       }

--- a/lib/util/batch.js
+++ b/lib/util/batch.js
@@ -3,7 +3,6 @@
 var _ = require('lodash')
   , promisify = require('./promisify')
   , Query = require('./query')
-  , parseVersion = require('./parse-version')
   , batchTypes = {
     standard: 0,
     unlogged: 1,
@@ -118,9 +117,8 @@ function yieldErrors(errors, callback) {
   callback(e);
 }
 
-function supportsCql31(versionString) {
-  var v = parseVersion(versionString);
-  return v.major > 3 || (v.major === 3 && v.minor >= 1);
+function supportsCql31(version) {
+  return version.major > 3 || (version.major === 3 && version.minor >= 1);
 }
 
 var endsWithSemicolonRegex = new RegExp(/\s*;\s*$/);
@@ -244,7 +242,7 @@ function executeBatch(callback) {
     self.context.timestamp,
     self.context.batchType,
     self.context.consistencyHierarchy,
-    self.db.config.cqlVersion,
+    self.db.config.parsedCqlVersion,
     self.context.hasChildBatch,
     false);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "priam",
-  "version": "0.8.11",
+  "version": "0.8.12",
   "description": "A simple Cassandra driver. It wraps the helenus and node-cassandra-cql drivers with additional error/retry handling, external .cql file support, and connection option resolution from an external source, among other improvements.",
   "keywords": [
     "cassandra",
@@ -21,7 +21,8 @@
     "async": "~0.9.0",
     "helenus": "~0.6.10",
     "lodash": "~2.4.1",
-    "node-cassandra-cql": "git://github.com/kitcambridge/node-cassandra-cql.git#4fbcbf6bb112c3684b28ccf10f3039e4aa9304a8",
+    "node-cassandra-cql": "^0.5.0",
+    "priam-cassandra-cql": "0.4.6",
     "q": "~1.0.1",
     "uuid": "~1.4.1"
   },

--- a/test/unit/driver.tests.js
+++ b/test/unit/driver.tests.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var sinon = require('sinon'),
-  chai = require('chai'),
-  util = require('util'),
-  assert = chai.assert,
-  expect = chai.expect;
-
-var Driver = require('../../lib/driver'),
-  helenus = require('../../lib/drivers/helenus'),
-  cassandraCql = require('../../lib/drivers/node-cassandra-cql');
+var sinon = require('sinon')
+  , chai = require('chai')
+  , util = require('util')
+  , assert = chai.assert
+  , expect = chai.expect
+  , Driver = require('../../lib/driver')
+  , helenus = require('../../lib/drivers/helenus')
+  , cassandraCql = require('../../lib/drivers/node-cassandra-cql')
+  , parseVersion = require('../../lib/util/parse-version');
 
 describe('lib/driver.js', function () {
 
@@ -18,34 +18,83 @@ describe('lib/driver.js', function () {
       assert.strictEqual(typeof Driver, 'function', 'exports a constructor function');
     });
 
-    it('returns cassandra-cql driver by default', function () {
+    it('returns latest node-cassandra-cql driver by default', function () {
       // arrange
-      var context = {
-        config: {
-        }
-      };
+      var context = null;
+      var parsed = parseVersion('3.1.0');
 
       // act
       var driver = Driver(context);
 
       // assert
-      assert.ok(driver instanceof cassandraCql.NodeCassandraDriver);
+      assert.strictEqual(driver.config.version, '3.1.0');
+      assert.deepEqual(driver.config.parsedCqlVersion, parsed);
+      assert.strictEqual(driver.config.driver, 'node-cassandra-cql');
+      assert.strictEqual(driver.config.protocol, 'binaryV2');
+      assert.instanceOf(driver, cassandraCql.NodeCassandraDriver);
     });
 
-    it('returns helenus driver if specified', function () {
+    it('returns helenus driver if specified as "helenus" and null cqlVersion', function () {
+      testInstance('helenus', 'cqlVersion', null, 'helenus', '3.1.0', 'thrift', helenus.HelenusDriver);
+    });
+
+    it('returns helenus driver if specified as "thrift" and null cqlVersion', function () {
+      testInstance('thrift', 'cqlVersion', null, 'helenus', '3.1.0', 'thrift', helenus.HelenusDriver);
+    });
+
+    it('returns helenus driver if cqlVersion is less than 3', function () {
+      testInstance('node-cassandra-cql', 'cqlVersion', '2.0.0', 'helenus', '2.0.0', 'thrift', helenus.HelenusDriver);
+    });
+
+    it('returns priam-cassandra-cql driver if cqlVersion is less than 3.1', function () {
+      testInstance('node-cassandra-cql', 'cqlVersion', '3.0.0', 'priam-cassandra-cql', '3.0.0', 'binaryV1', cassandraCql.NodeCassandraDriver);
+    });
+
+    it('returns node-cassandra-cql driver if cqlVersion is greater than 3.1', function () {
+      testInstance('node-cassandra-cql', 'cqlVersion', '3.2.0', 'node-cassandra-cql', '3.2.0', 'binaryV2', cassandraCql.NodeCassandraDriver);
+    });
+
+    it('returns helenus driver if specified as "helenus" and null version', function () {
+      testInstance('helenus', 'version', null, 'helenus', '3.1.0', 'thrift', helenus.HelenusDriver);
+    });
+
+    it('returns helenus driver if specified as "thrift" and null version', function () {
+      testInstance('thrift', 'version', null, 'helenus', '3.1.0', 'thrift', helenus.HelenusDriver);
+    });
+
+    it('returns helenus driver if version is less than 3', function () {
+      testInstance('node-cassandra-cql', 'version', '2.0.0', 'helenus', '2.0.0', 'thrift', helenus.HelenusDriver);
+    });
+
+    it('returns priam-cassandra-cql driver if version is greater than 3.1', function () {
+      testInstance('node-cassandra-cql', 'version', '3.0.0', 'priam-cassandra-cql', '3.0.0', 'binaryV1', cassandraCql.NodeCassandraDriver);
+    });
+
+    it('returns node-cassandra-cql driver if version is greater than 3.1', function () {
+      testInstance('node-cassandra-cql', 'version', '3.2.0', 'node-cassandra-cql', '3.2.0', 'binaryV2', cassandraCql.NodeCassandraDriver);
+    });
+
+    function testInstance(driver, versionPath, cqlVersion, expectedDriver, expectedVersion, expectedProtocol, expectedInstance) {
       // arrange
       var context = {
         config: {
-          driver: 'helenus'
+          driver: driver
         }
       };
+      context.config[versionPath] = cqlVersion;
+      var parsed = parseVersion(expectedVersion);
 
       // act
-      var driver = Driver(context);
+      var instance = Driver(context);
+      var config = instance.config;
 
       // assert
-      assert.ok(driver instanceof helenus.HelenusDriver);
-    });
+      assert.strictEqual(config.cqlVersion || config.version, expectedVersion); /* helenus is cqlVersion, node-cass-cql is version */
+      assert.deepEqual(config.parsedCqlVersion, parsed);
+      assert.strictEqual(config.driver, expectedDriver);
+      assert.strictEqual(config.protocol, expectedProtocol);
+      assert.instanceOf(instance, expectedInstance);
+    }
 
   });
 

--- a/test/unit/drivers/helenus.tests.js
+++ b/test/unit/drivers/helenus.tests.js
@@ -27,6 +27,7 @@ describe('lib/drivers/helenus.js', function () {
 
   function getDefaultConfig() {
     return {
+      cqlVersion: '3.0.0',
       hosts: ['123.456.789.012:9160'],
       keyspace: 'myKeySpace',
       timeout: 12345
@@ -105,7 +106,6 @@ describe('lib/drivers/helenus.js', function () {
     it('sets default pool configuration', function () {
       // arrange
       var config = _.extend({ }, getDefaultConfig());
-      var cqlVersion = '3.0.0';
       var consistencyLevel = helenus.ConsistencyLevel.ONE;
 
       // act
@@ -115,7 +115,7 @@ describe('lib/drivers/helenus.js', function () {
       assert.deepEqual(instance.poolConfig.hosts, config.hosts, 'hosts should be passed through');
       assert.strictEqual(instance.poolConfig.keyspace, config.keyspace, 'keyspace should be passed through');
       assert.strictEqual(instance.poolConfig.timeout, config.timeout, 'timeout should be passed through');
-      assert.strictEqual(instance.poolConfig.cqlVersion, cqlVersion, 'cqlVersion should default to 3.0.0');
+      assert.strictEqual(instance.poolConfig.cqlVersion, config.cqlVersion, 'cqlVersion should be passed through');
       assert.strictEqual(instance.poolConfig.consistencyLevel, consistencyLevel, 'consistencyLevel should default to ONE');
     });
 

--- a/test/unit/drivers/node-cassandra-cql.tests.js
+++ b/test/unit/drivers/node-cassandra-cql.tests.js
@@ -11,12 +11,14 @@ var sinon = require('sinon')
 chai.use(require('sinon-chai'));
 
 var cql = require('node-cassandra-cql');
+var priamCql = require('priam-cassandra-cql');
 var Driver = require('../../../lib/drivers/node-cassandra-cql');
 
 describe('lib/drivers/node-cassandra-cql.js', function () {
 
   function getDefaultConfig() {
     return {
+      cqlVersion: '3.1.0',
       hosts: ['123.456.789.012:9042'],
       keyspace: 'myKeySpace',
       timeout: 12345
@@ -97,11 +99,43 @@ describe('lib/drivers/node-cassandra-cql.js', function () {
         new Driver({ });
       }).to.throw(Error, /missing context.config /i);
     });
+
+    it('should throw exception if config is missing from context', function () {
+      // arrange
+      // act, assert
+      expect(function () {
+        new Driver({ });
+      }).to.throw(Error, /missing context.config /i);
+    });
+
+    it('should instantiate the node-cassandra-cql driver when requested', function () {
+      // arrange
+      var config = _.extend({ }, getDefaultConfig());
+      config.driver = 'node-cassandra-cql';
+
+      // act
+      var instance = new Driver({ config: config });
+
+      // assert
+      assert.equal(instance.cqlDriver, cql);
+    });
+
+    it('should instantiate the priam-cassandra-cql driver when requested', function () {
+      // arrange
+      var config = _.extend({ }, getDefaultConfig());
+      config.driver = 'priam-cassandra-cql';
+
+      // act
+      var instance = new Driver({ config: config });
+
+      // assert
+      assert.equal(instance.cqlDriver, priamCql);
+    });
+
     it('sets default pool configuration', function () {
       // arrange
       var config = _.extend({ }, getDefaultConfig());
       var configCopy = _.extend({ }, config);
-      var cqlVersion = '3.0.0';
       var consistencyLevel = cql.types.consistencies.one;
 
       // act
@@ -111,7 +145,7 @@ describe('lib/drivers/node-cassandra-cql.js', function () {
       assert.deepEqual(instance.poolConfig.hosts, configCopy.hosts, 'hosts should be passed through');
       assert.strictEqual(instance.poolConfig.keyspace, configCopy.keyspace, 'keyspace should be passed through');
       assert.strictEqual(instance.poolConfig.getAConnectionTimeout, configCopy.timeout, 'timeout should be passed through');
-      assert.strictEqual(instance.poolConfig.version, cqlVersion, 'version should default to 3.0.0');
+      assert.strictEqual(instance.poolConfig.version, configCopy.cqlVersion, 'cqlVersion should be passed through');
       assert.strictEqual(instance.poolConfig.consistencyLevel, consistencyLevel, 'consistencyLevel should default to ONE');
     });
 

--- a/test/unit/util/batch.tests.js
+++ b/test/unit/util/batch.tests.js
@@ -17,7 +17,7 @@ describe('lib/util/batch.js', function () {
   beforeEach(function () {
     db = {
       poolConfig: {},
-      config: { cqlVersion: '3.1.0' },
+      config: { parsedCqlVersion: { major: 3, minor: 1, patch: 0 } },
       param: function (value, hint) {
         return { value: value, hint: hint};
       },
@@ -1285,7 +1285,7 @@ describe('lib/util/batch.js', function () {
           batch.addBatch(childBatch);
           batch.timestamp(7654321);
 
-          db.config.cqlVersion = '3.0.0';
+          db.config.parsedCqlVersion = {major: 3, minor: 0, patch: 0};
           db.cql = sinon.stub().yields(null, data);
 
           // act


### PR DESCRIPTION
- Add support for BinaryV1 and BinaryV2 based on `cqlVersion`.
- Automatically choose the appropriate driver if the specified `cqlVersion` does not support it.
