### PR TITLE
Fix parameterized queries for Cassandra 1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,7 @@ var db = require('priam')({
 
 Release Notes
 -------------
+ - `0.9.2`: Fix parameterized queries over binary protocol v1.
  - `0.9.1`: Dependency updates.
  - `0.9.0`: Removed `node-cassandra-cql` in favor of `cassandra-driver`.
  - `0.8.17`: Batch.execute no longer yields an error when the batch is empty.

--- a/lib/drivers/datastax/driver.js
+++ b/lib/drivers/datastax/driver.js
@@ -3,9 +3,9 @@
 var _ = require('lodash')
   , util = require('util')
   , uuid = require('uuid')
-  , BaseDriver = require('./base-driver')
-  , cqlDriver = require('cassandra-driver');
-
+  , BaseDriver = require('../base-driver')
+  , cqlDriver = require('cassandra-driver')
+  , queryParser = require('./query-parser');
 
 function DatastaxDriver() {
   BaseDriver.call(this);
@@ -35,7 +35,7 @@ function DatastaxDriver() {
 }
 util.inherits(DatastaxDriver, BaseDriver);
 
-module.exports = function (context) {
+module.exports = function dataStaxDriverFactory(context) {
   var driver = new DatastaxDriver();
   driver.init(context);
   return driver;
@@ -163,6 +163,13 @@ DatastaxDriver.prototype.executeCqlOnDriver = function executeCqlOnDriver(pool, 
     prepare: !!options.executeAsPrepared,
     consistency: consistency
   }, options);
+
+  if (!execOptions.prepare && (pool.controlConnection.protocolVersion < 2)) {
+    // Stringify parameters for unprepared statements over binary v1
+    cqlStatement = queryParser.parse(cqlStatement, params);
+    params = [];
+  }
+
   var hints = [];
   _.forEach(params, function (param, index) {
     if (param && param.hasOwnProperty('value') && param.hasOwnProperty('hint')) {

--- a/lib/drivers/datastax/index.js
+++ b/lib/drivers/datastax/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./driver');

--- a/lib/drivers/datastax/query-parser.js
+++ b/lib/drivers/datastax/query-parser.js
@@ -1,0 +1,43 @@
+'use strict';
+
+/**
+  Migrated from https://github.com/jorgebay/node-cassandra-cql/blob/protocol1/lib/types.js
+  for backwards-compatibility with Jorge Gondra's node-cassandra-cql driver.
+ */
+
+var stringifier = require('./string-encoder').stringifyValue;
+
+var queryParser = {
+  /**
+   * Replaced the query place holders with the stringified value
+   * @param {String} query
+   * @param {Array} params
+   * @param {Function} stringifier
+   */
+  parse: function (query, params) {
+    if (!query || !query.length || !params) {
+      return query;
+    }
+    var parts = [];
+    var isLiteral = false;
+    var lastIndex = 0;
+    var paramsCounter = 0;
+    for (var i = 0; i < query.length; i++) {
+      var char = query.charAt(i);
+      if (char === "'" && query.charAt(i-1) !== '\\') {
+        //opening or closing quotes in a literal value of the query
+        isLiteral = !isLiteral;
+      }
+      if (!isLiteral && char === '?') {
+        //is a placeholder
+        parts.push(query.substring(lastIndex, i));
+        parts.push(stringifier(params[paramsCounter++]));
+        lastIndex = i+1;
+      }
+    }
+    parts.push(query.substring(lastIndex));
+    return parts.join('');
+  }
+};
+
+module.exports = queryParser;

--- a/lib/drivers/datastax/string-encoder.js
+++ b/lib/drivers/datastax/string-encoder.js
@@ -1,0 +1,183 @@
+'use strict';
+
+/**
+  Migrated from https://github.com/jorgebay/node-cassandra-cql/blob/protocol1/lib/encoder.js
+  for backwards-compatibility with Jorge Gondra's node-cassandra-cql driver.
+ */
+
+var util = require('util');
+var uuid = require('uuid');
+var ds = require('cassandra-driver');
+var types = ds.types;
+var dataTypes = types.dataTypes;
+var Long = types.Long;
+
+function stringifyValue (item) {
+  if (item === null || item === undefined) {
+    return 'NULL';
+  }
+  var value = item;
+  var type = null;
+  var subtypes = null;
+  if (item.hint !== null && item.hint !== undefined) {
+    value = item.value;
+    type = item.hint;
+    if (typeof type === 'string') {
+      var typeInfo = dataTypes.getByName(type);
+      type = typeInfo.type;
+      subtypes = typeInfo.subtypes;
+    }
+  }
+  if (value === null || value === undefined) {
+    return 'NULL';
+  }
+  if (type === null) {
+    type = guessDataType(value);
+    if (!type) {
+      throw new TypeError('Target data type could not be guessed, you must specify a hint.', value);
+    }
+  }
+  switch (type) {
+    case dataTypes.int:
+    case dataTypes.float:
+    case dataTypes.double:
+    case dataTypes.boolean:
+    case dataTypes.uuid:
+    case dataTypes.timeuuid:
+      return value.toString();
+    case dataTypes.text:
+    case dataTypes.varchar:
+    case dataTypes.ascii:
+      return quote(value);
+    case dataTypes.custom:
+    case dataTypes.decimal:
+    case dataTypes.inet:
+    case dataTypes.varint:
+    case dataTypes.blob:
+      return stringifyBuffer(value);
+    case dataTypes.bigint:
+    case dataTypes.counter:
+      return stringifyBigNumber(value);
+    case dataTypes.timestamp:
+      return stringifyDate(value);
+    case dataTypes.list:
+      return stringifyArray(value, subtypes && subtypes[0]);
+    case dataTypes.set:
+      return stringifyArray(value, subtypes && subtypes[0], '{', '}');
+    case dataTypes.map:
+      return stringifyMap(value, subtypes && subtypes[0], subtypes && subtypes[1]);
+    default:
+      throw new TypeError('Type not supported ' + type, value);
+  }
+}
+
+function stringifyBuffer(value) {
+  return '0x' + value.toString('hex');
+}
+
+function stringifyDate (value) {
+  return value.getTime().toString();
+}
+
+function quote(value) {
+  if (typeof value !== 'string') {
+    throw new TypeError(null, value, 'string');
+  }
+  value = value.replace(/'/g, "''"); // escape strings with double single-quotes
+  return "'" + value + "'";
+}
+
+function stringifyBigNumber (value) {
+  var buf = getBigNumberBuffer(value);
+  if (buf === null) {
+    throw new TypeError(null, value, Long);
+  }
+  return 'blobAsBigint(' + stringifyBuffer(buf) + ')';
+}
+
+function getBigNumberBuffer (value) {
+  var buf = null;
+  if (value instanceof Buffer) {
+    buf = value;
+  } else if (value instanceof Long) {
+    buf = Long.toBuffer(value);
+  } else if (typeof value === 'number') {
+    buf = Long.toBuffer(Long.fromNumber(value));
+  }
+  return buf;
+}
+
+function stringifyArray (value, subtype, openChar, closeChar) {
+  if (!openChar) {
+    openChar = '[';
+    closeChar = ']';
+  }
+  var stringValues = [];
+  for (var i = 0; i < value.length; i++) {
+    var item = value[i];
+    if (subtype) {
+      item = {hint: subtype, value: item};
+    }
+    stringValues.push(stringifyValue(item));
+  }
+  return openChar + stringValues.join() + closeChar;
+}
+
+function stringifyMap (value, keyType, valueType) {
+    var stringValues = [];
+    var keys = Object.keys(value);
+    for (var i = 0; i < keys.length; i++) {
+      var key = keys[i];
+      var mapKey = key;
+      if (keyType) {
+        mapKey = {hint: keyType, value: mapKey};
+      }
+      var mapValue = value[key];
+      if (valueType) {
+        mapValue = {hint: valueType, value: mapValue};
+      }
+      stringValues.push(stringifyValue(mapKey) + ':' + stringifyValue(mapValue));
+    }
+    return '{' + stringValues.join() + '}';
+  }
+
+
+/**
+ * Try to guess the Cassandra type to be stored, based on the javascript value type
+ */
+function guessDataType (value) {
+  var dataType = null;
+  if (typeof value === 'number') {
+    dataType = dataTypes.int;
+    if (value % 1 !== 0) {
+      dataType = dataTypes.double;
+    }
+  }
+  else if(value instanceof Date) {
+    dataType = dataTypes.timestamp;
+  }
+  else if(value instanceof Long) {
+    dataType = dataTypes.bigint;
+  }
+  else if (typeof value === 'string') {
+    dataType = dataTypes.text;
+    if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)){
+      dataType = dataTypes.uuid;
+    }
+  }
+  else if (value instanceof Buffer) {
+    dataType = dataTypes.blob;
+  }
+  else if (util.isArray(value)) {
+    dataType = dataTypes.list;
+  }
+  else if (value === true || value === false) {
+    dataType = dataTypes.boolean;
+  }
+  return dataType;
+}
+
+module.exports = {
+  stringifyValue: stringifyValue,
+  guessDataType: guessDataType
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "priam",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "A simple Cassandra driver. It wraps the helenus and cassandra-driver Cassandra drivers with additional error/retry handling, external .cql file support, and connection option resolution from an external source, query composition, among other improvements.",
   "keywords": [
     "cassandra",

--- a/test/unit/drivers/datastax/query-parser.tests.js
+++ b/test/unit/drivers/datastax/query-parser.tests.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var sinon = require('sinon')
+  , chai = require('chai')
+  , assert = chai.assert;
+
+var parser = require('../../../../lib/drivers/datastax/query-parser');
+
+describe('lib/drivers/datastax/query-parser.js', function () {
+
+  describe('#parse()', function () {
+    var parse = parser.parse;
+    it('returns original CQL if there are no params', function () {
+      var query = 'SELECT * FROM my_column_family';
+      assert.strictEqual(parse(query), query, 'Did not return the appropriate CQL');
+    });
+    it('returns empty if there is no query', function () {
+      var query = '';
+      assert.strictEqual(parse(query, [1,2,3]), query, 'Did not return the appropriate CQL');
+    });
+    it('generates appropriate CQL with stringified params', function() {
+      var query = 'UPDATE "myColumnFamily" SET field1 = ?, field2 = ? WHERE key1=\'something\' AND key2=? USING TIMESTAMP ?';
+      var params = ['field1', 'field\'2', 'key2', ((new Date()).getTime() * 1000)];
+      var expected = 'UPDATE "myColumnFamily" SET field1 = \'field1\', field2 = \'field\'\'2\' WHERE key1=\'something\' AND key2=\'key2\' USING TIMESTAMP ' + params[params.length - 1].toString();
+
+      assert.strictEqual(parse(query, params), expected, 'Did not generate the appropriate stringified CQL');
+    });
+  });
+
+});

--- a/test/unit/drivers/datastax/string-encoder.tests.js
+++ b/test/unit/drivers/datastax/string-encoder.tests.js
@@ -1,0 +1,117 @@
+'use strict';
+
+var sinon = require('sinon')
+  , chai = require('chai')
+  , assert = chai.assert
+  , expect = chai.expect;
+
+var ds = require('cassandra-driver');
+var uuid = require('uuid');
+var types = ds.types;
+var dataTypes = types.dataTypes;
+var Long = types.Long;
+var encoder = require('../../../../lib/drivers/datastax/string-encoder');
+
+describe('lib/drivers/datastax/string-encoder.js', function () {
+
+  describe('#stringifyValue()', function () {
+    var stringify = encoder.stringifyValue;
+    it('returns "NULL" for null values', function() {
+      assert.strictEqual(stringify(null), 'NULL', 'null value should be "NULL"');
+      assert.strictEqual(stringify(undefined), 'NULL', 'undefined value should be "NULL"');
+      assert.strictEqual(stringify({ value: null, hint: dataTypes.ascii }), 'NULL', 'null value should be "NULL"');
+      assert.strictEqual(stringify({ value: undefined, hint: dataTypes.ascii }), 'NULL', 'null value should be "NULL"');
+    });
+    it('guesses data type if type hint is not provided', function() {
+      assert.strictEqual(stringify(12345), '12345', 'stringify for guessed int value failed');
+      var fail = stringify.bind(encoder, { my: 'object'});
+      expect(fail).to.throw(TypeError);
+    });
+    it('returns simple numeric values as strings', function() {
+      assert.strictEqual(stringify({ value: 12345, hint: dataTypes.int }), '12345', 'stringify for int value failed');
+      assert.strictEqual(stringify({ value: 12345.1234, hint: dataTypes.float }), '12345.1234', 'stringify for float value failed');
+      assert.strictEqual(stringify({ value: 123451234512345.12, hint: dataTypes.double }), '123451234512345.12', 'stringify for double value failed');
+    });
+    it('returns boolean values as strings', function() {
+      assert.strictEqual(stringify({ value: true, hint: dataTypes.boolean }), 'true', 'stringify for boolean value failed');
+      assert.strictEqual(stringify({ value: false, hint: dataTypes.boolean }), 'false', 'stringify for boolean value failed');
+    });
+    it('returns uuid values as strings', function() {
+      var id = uuid.v4();
+      assert.strictEqual(stringify({ value: id, hint: dataTypes.uuid }), id.toString(), 'stringify for uuid value failed');
+      assert.strictEqual(stringify({ value: id, hint: dataTypes.timeuuid }), id.toString(), 'stringify for timeuuid value failed');
+    });
+    it('quotes string values', function() {
+      assert.strictEqual(stringify({ value: 'ab\'cd', hint: dataTypes.ascii }), '\'ab\'\'cd\'', 'stringify for ascii value failed');
+      assert.strictEqual(stringify({ value: 'ab\'cd', hint: dataTypes.text }), '\'ab\'\'cd\'', 'stringify for text value failed');
+      assert.strictEqual(stringify({ value: 'ab\'cd', hint: dataTypes.varchar }), '\'ab\'\'cd\'', 'stringify for varchar value failed');
+      expect(stringify.bind(encoder, { value: 12345, hint: dataTypes.ascii })).to.throw(TypeError);
+    });
+    it('returns buffer values as strings', function() {
+      var buffer = new Buffer('foobar');
+      var expected = '0x' + buffer.toString('hex');
+      assert.strictEqual(stringify({ value: buffer, hint: dataTypes.custom }), expected, 'stringify for custom value failed');
+      assert.strictEqual(stringify({ value: buffer, hint: dataTypes.decimal }), expected, 'stringify for decimal value failed');
+      assert.strictEqual(stringify({ value: buffer, hint: dataTypes.inet }), expected, 'stringify for inet value failed');
+      assert.strictEqual(stringify({ value: buffer, hint: dataTypes.varint }), expected, 'stringify for varint value failed');
+      assert.strictEqual(stringify({ value: buffer, hint: dataTypes.blob }), expected, 'stringify for blob value failed');
+    });
+    it('returns big number values as strings', function () {
+      var l = Long.fromNumber(12345);
+      var expected = 'blobAsBigint(0x' + Long.toBuffer(l).toString('hex') + ')';
+      assert.strictEqual(stringify({ value: l, hint: dataTypes.bigint }), expected, 'stringify for bigint Long value failed');
+      assert.strictEqual(stringify({ value: 12345, hint: dataTypes.bigint }), expected, 'stringify for bigint numeric value failed');
+      assert.strictEqual(stringify({ value: Long.toBuffer(l), hint: dataTypes.bigint }), expected, 'stringify for bigint Buffer value failed');
+      expect(stringify.bind(encoder, { value: 'notaninteger', hint: dataTypes.bigint })).to.throw(TypeError);
+    });
+    it('returns timestamp values as strings of ticks', function () {
+      var d = new Date();
+      var expected = d.getTime().toString();
+      assert.strictEqual(stringify({ value: d, hint: dataTypes.timestamp }), expected, 'stringify for timestamp value failed');
+    });
+    it('returns list values as stringified array', function () {
+      var list = [1, 2, 3, 4, 5];
+      var expected = '[1,2,3,4,5]';
+      assert.strictEqual(stringify({ value: list, hint: 'list<int>' }), expected, 'stringify for list<int> value failed');
+      assert.strictEqual(stringify({ value: list, hint: dataTypes.list }), expected, 'stringify for list value failed');
+    });
+    it('returns set values as stringified object', function () {
+      var set = [1, 2, 3, 4, 5];
+      var expected = '{1,2,3,4,5}';
+      assert.strictEqual(stringify({ value: set, hint: 'set<int>' }), expected, 'stringify for list<int> value failed');
+      assert.strictEqual(stringify({ value: set, hint: dataTypes.set }), expected, 'stringify for list value failed');
+    });
+    it('returns map values as stringified object', function () {
+      var map = {
+        a: 123,
+        b: 234
+      };
+      var expected = '{\'a\':123,\'b\':234}';
+      assert.strictEqual(stringify({ value: map, hint: 'map<text,int>' }), expected, 'stringify for map<text,int> value failed');
+      assert.strictEqual(stringify({ value: map, hint: dataTypes.map }), expected, 'stringify for map value failed');
+      assert.strictEqual(stringify({ value: {}, hint: dataTypes.map }), '{}', 'stringify for map empty object value failed');
+    });
+    it('throws for unsupported types', function () {
+      expect(stringify.bind(encoder, { value: 'foobar', hint: 12345 })).to.throw(TypeError);
+    });
+  });
+
+  describe('#guessDataType()', function () {
+    var guessDataType = encoder.guessDataType;
+    it('should guess the native types', function () {
+      assert.strictEqual(guessDataType(12345), dataTypes.int, 'Guess type for an integer number failed');
+      assert.strictEqual(guessDataType(1.01), dataTypes.double, 'Guess type for a double number failed');
+      assert.strictEqual(guessDataType(true), dataTypes.boolean, 'Guess type for a boolean value failed');
+      assert.strictEqual(guessDataType(false), dataTypes.boolean, 'Guess type for a boolean value failed');
+      assert.strictEqual(guessDataType([1,2,3]), dataTypes.list, 'Guess type for an Array value failed');
+      assert.strictEqual(guessDataType('a string'), dataTypes.text, 'Guess type for an string value failed');
+      assert.strictEqual(guessDataType(new Buffer('bip bop')), dataTypes.blob, 'Guess type for a buffer value failed');
+      assert.strictEqual(guessDataType(new Date()), dataTypes.timestamp, 'Guess type for a Date value failed');
+      assert.strictEqual(guessDataType(new types.Long(10)), dataTypes.bigint, 'Guess type for a Int 64 value failed');
+      assert.strictEqual(guessDataType(uuid.v4()), dataTypes.uuid, 'Guess type for a UUID value failed');
+      assert.strictEqual(guessDataType(types.uuid()), dataTypes.uuid, 'Guess type for a UUID value failed');
+      assert.strictEqual(guessDataType(types.timeuuid()), dataTypes.uuid, 'Guess type for a Timeuuid value failed');
+    });
+  });
+
+});


### PR DESCRIPTION
The query stringification for non-prepared execution in C\* 1.2 was not migrated from `node-cassandra-cql` to `cassandra-driver`. This ports the stringify code from the old driver into Priam for backwards-compatibility purposes.
