### PR TITLE
Actually use the `keyspace` option passed in to priam drivers.

### DIFF
--- a/lib/drivers/base-driver.js
+++ b/lib/drivers/base-driver.js
@@ -44,6 +44,7 @@ BaseDriver.prototype.init = function init(context) {
   }
 
   this.initProviderOptions(this.config);
+  this.keyspace = context.config.keyspace;
   this.poolConfig = {
     consistencyLevel: this.consistencyLevel.one
   };
@@ -203,7 +204,7 @@ function performConnect(keyspace, waitForConnect, callback) {
 BaseDriver.prototype.execCql = function execCql(cql, dataParams, options, callback) {
   /* istanbul ignore next: no benefit of testing coalesce for keyspace retrieval */
   var self = this
-    , keyspace = (options || {}).keyspace
+    , keyspace = (options || {}).keyspace || this.keyspace
     , consistency = options.consistency || self.poolConfig.consistencyLevel || self.consistencyLevel.one;
 
   performConnect.call(self, keyspace, false, function (err, pool) {


### PR DESCRIPTION
This option was not actually getting used. When using multiple keyspaces this would cause the first keyspace to always be used.
