### PR TITLE
BOM fix

### DIFF
--- a/lib/util/query-cache.js
+++ b/lib/util/query-cache.js
@@ -31,7 +31,8 @@ QueryCache.prototype.initQueries = function initQueries() {
     , fileCache = this.fileCache
     , files = fs.readdirSync(queryDir);
   files.forEach(function (filePath) {
-    fileCache[path.basename(filePath, ".cql")] = fs.readFileSync(path.join(queryDir, filePath), "utf8");
+    var fileContent = fs.readFileSync(path.join(queryDir, filePath), "utf8").replace(/^\uFEFF/, ''); // remove BOM
+    fileCache[path.basename(filePath, ".cql")] = fileContent;
   });
 };
 

--- a/test/stubs/cql/cqlFileWithBOM.cql
+++ b/test/stubs/cql/cqlFileWithBOM.cql
@@ -1,0 +1,1 @@
+﻿SELECT * FROM "myColumnFamily"

--- a/test/unit/drivers/datastax.tests.js
+++ b/test/unit/drivers/datastax.tests.js
@@ -1868,6 +1868,19 @@ describe('lib/drivers/datastax', function () {
       });
     });
 
+    it('handles CQL files containing a BOM', function (done) {
+      // arrange
+      var queryName = 'cqlFileWithBOM';
+      var params = [];
+      var consistency = cql.types.consistencies.one;
+
+      // act
+      instance.namedQuery(queryName, params, { consistency: consistency }, function () {
+        expect(instance.execCql.firstCall.args[0]).to.equal('SELECT * FROM "myColumnFamily"');
+        done();
+      });
+    });
+
     it('allows caller to disable prepared statement', function (done) {
       // arrange
       var queryName = 'myFakeCql';


### PR DESCRIPTION
The byte order mark (BOM) in some UTF-8 files (usually created in Windows) is not eliminated by node when reading the file. We discovered that this BOM is then passed on to Cassandra, which complains about not recognizing the first character. This code will automatically strip the character.