### PR TITLE
Added the tracing for individual query names inside a batch

### DIFF
--- a/lib/drivers/base-driver.js
+++ b/lib/drivers/base-driver.js
@@ -333,7 +333,7 @@ BaseDriver.prototype.cql = function executeCqlQuery(cqlQuery, dataParams, option
   options = p.options;
   callback = p.callback;
 
-  captureMetrics = !!(metrics && options.queryName);
+  captureMetrics = !!(metrics && (options.queryName || options.batchQueryNames));
 
   if (!options.suppressDebugLog) {
     var debugParams = [];
@@ -412,7 +412,13 @@ BaseDriver.prototype.cql = function executeCqlQuery(cqlQuery, dataParams, option
         if (captureMetrics) {
           var duration = process.hrtime(start);
           duration = (duration[0] * 1e3) + (duration[1] / 1e6);
-          metrics.measurement('query.' + options.queryName, duration, 'ms');
+          if (options.batchQueryNames) {
+            options.batchQueryNames.forEach(function (batchQueryName) {
+              metrics.measurement('query.' + batchQueryName, duration, 'ms');
+            });
+          } else {
+            metrics.measurement('query.' + options.queryName, duration, 'ms');
+          }
         }
         if (typeof callback === 'function') {
           if (result && result.length && options && options.resultTransformers && options.resultTransformers.length) {

--- a/lib/util/batch.js
+++ b/lib/util/batch.js
@@ -155,7 +155,7 @@ function containsDeleteOrUpdateStatement(query) {
 }
 
 var endsWithSemicolonRegex = /\s*;\s*$/;
-function joinQueries(queries, timestamp, batchType, consistencyHierarchy, cqlVersion, hasChildBatch, isChildBatch) {
+function joinQueries(queries, timestamp, batchType, consistencyHierarchy, cqlVersion, hasChildBatch, isChildBatch, batchQueryNames) {
   var cql = []
     , params = []
     , options = {}
@@ -164,6 +164,9 @@ function joinQueries(queries, timestamp, batchType, consistencyHierarchy, cqlVer
     , hasQuery = false
     , supportsNestedTimestamp = typeof cqlVersion === 'boolean' ? cqlVersion : supportsCql31(cqlVersion)
     , queryConsistencyMap;
+
+  batchQueryNames = batchQueryNames || [];
+
   if (!isChildBatch) {
     cql.push('BEGIN ' + getBatchTypeString(batchType) + 'BATCH');
   }
@@ -199,7 +202,8 @@ function joinQueries(queries, timestamp, batchType, consistencyHierarchy, cqlVer
         query.context.consistencyHierarchy,
         supportsNestedTimestamp,
         query.context.hasChildBatch,
-        true);
+        true,
+        batchQueryNames);
       queryCql = childBatch.cql;
       params = params.concat(childBatch.params);
       hasQuery = !!(hasQuery || queryCql);
@@ -228,6 +232,12 @@ function joinQueries(queries, timestamp, batchType, consistencyHierarchy, cqlVer
       cql.push(queryCql);
     }
 
+    // Adding the individual query name for tracing
+    var batchQueryName = query.context.options.queryName;
+    if (batchQueryName) {
+      batchQueryNames.push(batchQueryName);
+    }
+
     // If any of the queries suppresses debug, the batch should also
     if (query.context.options.suppressDebugLog === true) {
       options.suppressDebugLog = true;
@@ -245,6 +255,8 @@ function joinQueries(queries, timestamp, batchType, consistencyHierarchy, cqlVer
   if (!isChildBatch) {
     cql.push('APPLY BATCH;\n');
   }
+
+  options.batchQueryNames = batchQueryNames;
 
   return {
     cql: hasQuery ? cql.join('\n') : null,

--- a/test/unit/drivers/datastax.tests.js
+++ b/test/unit/drivers/datastax.tests.js
@@ -1256,6 +1256,34 @@ describe('lib/drivers/datastax', function () {
       });
     });
 
+    it('captures metrics if metrics and batchQueryNames are provided', function (done) {
+      // arrange
+      var cqlQuery = 'MyBatchCqlStatement';
+      var batchQueryNames = ['batchQuery1', 'batchQuery2'];
+      var params = ['param1', 'param2', 'param3'];
+      var consistency = cql.types.consistencies.one;
+      var err = null;
+      var data = { field1: 'value1' };
+      var pool = getPoolStub(instance.config, true, err, data);
+      instance.pools = { myKeySpace: pool };
+      instance.metrics = {
+        measurement: sinon.stub()
+      };
+
+      // act
+      instance.cql(cqlQuery, params, { consistency: consistency, batchQueryNames: batchQueryNames }, function () {
+        var call1 = instance.metrics.measurement.getCall(0);
+        var call2 = instance.metrics.measurement.getCall(1);
+        
+        // assert
+        assert.ok(instance.metrics.measurement.calledTwice, 'measurement called twice');
+        assert.strictEqual(call1.args[0], 'query.' + batchQueryNames[0], 'measurement called with appropriate query name');
+        assert.strictEqual(call2.args[0], 'query.' + batchQueryNames[1], 'measurement called with appropriate query name');
+
+        done();
+      });
+    });
+
     describe('with connection resolver', function () {
 
       var logger, resolverOptions;

--- a/test/unit/drivers/helenus.tests.js
+++ b/test/unit/drivers/helenus.tests.js
@@ -934,6 +934,34 @@ describe('lib/drivers/helenus.js', function () {
       });
     });
 
+    it('captures metrics if metrics and batchQueryNames are provided', function (done) {
+      // arrange
+      var cql = 'MyBatchCqlStatement';
+      var batchQueryNames = ['batchQuery1', 'batchQuery2'];
+      var params = ['param1', 'param2', 'param3'];
+      var consistency = helenus.ConsistencyLevel.ONE;
+      var err = null;
+      var data = { field1: 'value1' };
+      var pool = getPoolStub(instance.config, true, err, data);
+      instance.pools = { myKeySpace: pool };
+      instance.metrics = {
+        measurement: sinon.stub()
+      };
+
+      // act
+      instance.cql(cql, params, { consistency: consistency, batchQueryNames: batchQueryNames }, function () {
+        var call1 = instance.metrics.measurement.getCall(0);
+        var call2 = instance.metrics.measurement.getCall(1);
+        
+        // assert
+        assert.ok(instance.metrics.measurement.calledTwice, 'measurement called twice');
+        assert.strictEqual(call1.args[0], 'query.' + batchQueryNames[0], 'measurement called with appropriate query name');
+        assert.strictEqual(call2.args[0], 'query.' + batchQueryNames[1], 'measurement called with appropriate query name');
+
+        done();
+      });
+    });
+
     describe('with connection resolver', function () {
 
       var logger = null;


### PR DESCRIPTION
Currently all queries inside a batch are not being captured for metrics. This change will assemble a list of the individual query names inside the batch and call metric for each one using the same batch duration for each.