### PR TITLE
Nodejs driver 2.2.0

### DIFF
--- a/lib/driver-factory.js
+++ b/lib/driver-factory.js
@@ -2,6 +2,7 @@
 
 var parseVersion = require('./util/parse-version');
 var Driver = require('./driver');
+var cqlTypes = require('./util/cql-types');
 
 function DriverFactory(context) {
   context = context || {};
@@ -18,3 +19,7 @@ function DriverFactory(context) {
 module.exports = function (context) {
   return DriverFactory(context);
 };
+
+module.exports.valueTypes = cqlTypes.valueTypes;
+module.exports.dataTypes = cqlTypes.dataTypes;
+module.exports.consistencies = cqlTypes.consistencies;

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -898,7 +898,7 @@ function coerceDataStaxType(value) {
     return value; // already a primitive, buffer, or null
   }
 
-  var testValue, type, i;
+  var testValue, i;
   if (Array.isArray(value)) {
     // Set/List types
     testValue = null;
@@ -909,13 +909,13 @@ function coerceDataStaxType(value) {
       }
     }
     if (testValue !== null) {
-      if ((type = getNumericDataStaxTypeName(testValue))) {
+      if (getNumericDataStaxTypeName(testValue)) {
         // Array of numerics
         value = value.map(function (v) {
           if (isNullOrUndefined(v)) { return v; }
-          return convertDataStaxNumericType(type, v);
+          return v.toNumber();
         });
-      } else if ((type = getStringDataStaxTypeName(testValue))) {
+      } else if (getStringDataStaxTypeName(testValue)) {
         // Array of strings
         value = value.map(function (v) {
           if (isNullOrUndefined(v)) { return v; }
@@ -923,10 +923,10 @@ function coerceDataStaxType(value) {
         });
       }
     }
-  } else if ((type = getNumericDataStaxTypeName(value))) {
+  } else if (getNumericDataStaxTypeName(value)) {
     // Numeric Types
-    return convertDataStaxNumericType(type, value);
-  } else if ((type = getStringDataStaxTypeName(value))) {
+    return value.toNumber();
+  } else if (getStringDataStaxTypeName(value)) {
     // String Types
     return value.toString();
   } else {
@@ -964,7 +964,7 @@ function coerceDataStaxType(value) {
           if (valueTypeIsString) {
             mappedValue = mappedValue.toString();
           } else if (valueType) {
-            mappedValue = convertDataStaxNumericType(valueType, mappedValue);
+            mappedValue = mappedValue.toNumber();
           }
         }
         transformed[key] = mappedValue;
@@ -974,13 +974,6 @@ function coerceDataStaxType(value) {
   }
 
   return value;
-}
-
-function convertDataStaxNumericType(type, value) {
-  if (type === 'BigDecimal') {
-    return parseFloat(value.toString());
-  }
-  return parseInt(value.toString(), 10);
 }
 
 function getStringDataStaxTypeName(value) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -9,6 +9,7 @@ var through = require('through2');
 var isStream  = require('isstream');
 var retry = require('retry');
 var cqlDriver = require('cassandra-driver');
+var cqlTypes = require('./util/cql-types');
 var fakeLogger = require('./util/fake-logger');
 var typeCheck = require('./util/type-check');
 var QueryCache = require('./util/query-cache');
@@ -22,14 +23,14 @@ function DatastaxDriver() {
   this.consistencyLevel = {};
   this.hostConfigKey = 'contactPoints';
 
-  this.types = _.merge({}, cqlDriverNumericTypes, cqlDriverStringTypes);
+  this.types = cqlTypes.valueTypes;
   this.dataType = _.extend(
     {
       objectAscii: -1,
       objectText: -2
     },
-    cqlDriver.types.dataTypes);
-  var consistencies = cqlDriver.types.consistencies;
+    cqlTypes.dataTypes);
+  var consistencies = cqlTypes.consistencies;
   this.consistencyLevel = {
     ONE: consistencies.one,
     one: consistencies.one,
@@ -877,11 +878,6 @@ function checkOptionalParameters(options, callback) {
   };
 }
 
-var cqlDriverNumericTypeNames = ['BigDecimal', 'Integer', 'Long'];
-var cqlDriverNumericTypes = _.pick(cqlDriver.types, cqlDriverNumericTypeNames);
-var cqlDriverStringTypeNames = ['TimeUuid', 'Uuid'];
-var cqlDriverStringTypes = _.pick(cqlDriver.types, cqlDriverStringTypeNames);
-
 function shouldCoerceDataStaxTypes(options, config) {
   /* istanbul ignore next: no benefit of testing coalesce */
   var coerce = (options || {}).coerceDataStaxTypes;
@@ -988,11 +984,11 @@ function convertDataStaxNumericType(type, value) {
 }
 
 function getStringDataStaxTypeName(value) {
-  return getDataStaxType(value, cqlDriverStringTypeNames, cqlDriverStringTypes);
+  return getDataStaxType(value, cqlTypes.stringValueTypeNames, cqlTypes.stringValueTypes);
 }
 
 function getNumericDataStaxTypeName(value) {
-  return getDataStaxType(value, cqlDriverNumericTypeNames, cqlDriverNumericTypes);
+  return getDataStaxType(value, cqlTypes.numericValueTypeNames, cqlTypes.numericValueTypes);
 }
 
 function getDataStaxType(value, typeNames, types) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -823,12 +823,20 @@ DatastaxDriver.prototype.beginBatch = function beginBatch() {
   return new Batch(this);
 };
 
+var validUuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 DatastaxDriver.prototype.param = function (value, hint, isRoutingKey) {
   if (!hint) {
     return value;
   }
 
   hint = (hint in this.dataType) ? this.dataType[hint] : hint;
+  if ((hint === this.dataType.uuid || hint === this.dataType.timeuuid) && typeof value === 'string') {
+    // If this is a special timeUuid function ( e.g. now() ), remove the hint or
+    // the DataStax driver will blow up.
+    if (!validUuidRegex.test(value)) {
+      return value; // let the driver figure out types
+    }
+  }
   return { value: value, hint: hint, isRoutingKey: isRoutingKey === true };
 };
 
@@ -879,7 +887,7 @@ function checkOptionalParameters(options, callback) {
 
 var cqlDriverNumericTypeNames = ['BigDecimal', 'Integer', 'Long'];
 var cqlDriverNumericTypes = _.pick(cqlDriver.types, cqlDriverNumericTypeNames);
-var cqlDriverStringTypeNames = ['Uuid', 'TimeUuid'];
+var cqlDriverStringTypeNames = ['TimeUuid', 'Uuid'];
 var cqlDriverStringTypes = _.pick(cqlDriver.types, cqlDriverStringTypeNames);
 
 function shouldCoerceDataStaxTypes(options, config) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -22,13 +22,13 @@ function DatastaxDriver() {
   this.consistencyLevel = {};
   this.hostConfigKey = 'contactPoints';
 
+  this.types = _.merge({}, cqlDriverNumericTypes, cqlDriverStringTypes);
   this.dataType = _.extend(
     {
       objectAscii: -1,
       objectText: -2
     },
     cqlDriver.types.dataTypes);
-
   var consistencies = cqlDriver.types.consistencies;
   this.consistencyLevel = {
     ONE: consistencies.one,
@@ -823,20 +823,12 @@ DatastaxDriver.prototype.beginBatch = function beginBatch() {
   return new Batch(this);
 };
 
-var validUuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 DatastaxDriver.prototype.param = function (value, hint, isRoutingKey) {
   if (!hint) {
     return value;
   }
 
   hint = (hint in this.dataType) ? this.dataType[hint] : hint;
-  if ((hint === this.dataType.uuid || hint === this.dataType.timeuuid) && typeof value === 'string') {
-    // If this is a special timeUuid function ( e.g. now() ), remove the hint or
-    // the DataStax driver will blow up.
-    if (!validUuidRegex.test(value)) {
-      return value; // let the driver figure out types
-    }
-  }
   return { value: value, hint: hint, isRoutingKey: isRoutingKey === true };
 };
 

--- a/lib/util/cql-types.js
+++ b/lib/util/cql-types.js
@@ -8,6 +8,7 @@ var cqlDriverNumericTypes = _.pick(cqlDriver.types, cqlDriverNumericTypeNames);
 var cqlDriverStringTypeNames = ['TimeUuid', 'Uuid'];
 var cqlDriverStringTypes = _.pick(cqlDriver.types, cqlDriverStringTypeNames);
 var cqlDriverTypes = _.merge({}, cqlDriverNumericTypes, cqlDriverStringTypes);
+var consistencies = cqlDriver.types.consistencies;
 
 module.exports = {
   numericValueTypeNames: cqlDriverNumericTypeNames,
@@ -16,5 +17,15 @@ module.exports = {
   stringValueTypes: cqlDriverStringTypes,
   valueTypes: cqlDriverTypes,
   dataTypes: cqlDriver.types.dataTypes,
-  consistencies: cqlDriver.types.consistencies
+  consistencies: _.merge({}, consistencies, {
+    ONE: consistencies.one,
+    TWO: consistencies.two,
+    THREE: consistencies.three,
+    QUORUM: consistencies.quorum,
+    LOCAL_QUORUM: consistencies.localQuorum,
+    LOCAL_ONE: consistencies.localOne,
+    EACH_QUORUM: consistencies.eachQuorum,
+    ALL: consistencies.all,
+    ANY: consistencies.any,
+  })
 };

--- a/lib/util/cql-types.js
+++ b/lib/util/cql-types.js
@@ -5,7 +5,7 @@ var cqlDriver = require('cassandra-driver');
 
 var cqlDriverNumericTypeNames = ['BigDecimal', 'Integer', 'Long'];
 var cqlDriverNumericTypes = _.pick(cqlDriver.types, cqlDriverNumericTypeNames);
-var cqlDriverStringTypeNames = ['TimeUuid', 'Uuid'];
+var cqlDriverStringTypeNames = ['TimeUuid', 'Uuid', 'InetAddress'];
 var cqlDriverStringTypes = _.pick(cqlDriver.types, cqlDriverStringTypeNames);
 var cqlDriverTypes = _.merge({}, cqlDriverNumericTypes, cqlDriverStringTypes);
 var consistencies = cqlDriver.types.consistencies;
@@ -26,6 +26,6 @@ module.exports = {
     LOCAL_ONE: consistencies.localOne,
     EACH_QUORUM: consistencies.eachQuorum,
     ALL: consistencies.all,
-    ANY: consistencies.any,
+    ANY: consistencies.any
   })
 };

--- a/lib/util/cql-types.js
+++ b/lib/util/cql-types.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var _ = require('lodash');
+var cqlDriver = require('cassandra-driver');
+
+var cqlDriverNumericTypeNames = ['BigDecimal', 'Integer', 'Long'];
+var cqlDriverNumericTypes = _.pick(cqlDriver.types, cqlDriverNumericTypeNames);
+var cqlDriverStringTypeNames = ['TimeUuid', 'Uuid'];
+var cqlDriverStringTypes = _.pick(cqlDriver.types, cqlDriverStringTypeNames);
+var cqlDriverTypes = _.merge({}, cqlDriverNumericTypes, cqlDriverStringTypes);
+
+module.exports = {
+  numericValueTypeNames: cqlDriverNumericTypeNames,
+  numericValueTypes: cqlDriverNumericTypes,
+  stringValueTypeNames: cqlDriverStringTypeNames,
+  stringValueTypes: cqlDriverStringTypes,
+  valueTypes: cqlDriverTypes,
+  dataTypes: cqlDriver.types.dataTypes,
+  consistencies: cqlDriver.types.consistencies
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "priam",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A simple Cassandra driver. It wraps the helenus and cassandra-driver modules with additional error/retry handling, external .cql file support, connection option resolution from an external source, and query composition, among other improvements.",
   "keywords": [
     "cassandra",
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "async": "^1.2.1",
-    "cassandra-driver": "^2.1.0",
+    "cassandra-driver": "^2.2.0",
     "isstream": "^0.1.2",
     "lodash": "^3.9.3",
     "q": "^1.4.1",

--- a/test/unit/driver-factory.tests.js
+++ b/test/unit/driver-factory.tests.js
@@ -36,6 +36,12 @@ describe('lib/driver-factory.js', function () {
       testInstance('datastax', 'cqlVersion', '3.0.0', 'datastax', '3.0.0', 'binary', Driver.DatastaxDriver);
     });
 
+    it('exposes DataStax types and consistencies', function () {
+      expect(DriverFactory.consistencies).to.be.an.object;
+      expect(DriverFactory.dataTypes).to.be.an.object;
+      expect(DriverFactory.valueTypes).to.be.an.object;
+    });
+
     function testInstance(driver, versionPath, cqlVersion, expectedDriver, expectedVersion, expectedProtocol, expectedInstance) {
       // arrange
       var context = {

--- a/test/unit/driver.basic.tests.js
+++ b/test/unit/driver.basic.tests.js
@@ -458,6 +458,26 @@ describe('lib/driver.js', function () {
       expect(driver.param('foo')).to.equal('foo');
     });
 
+    it('removes the type hint from timeuuid values if the value is not a valid uuid', function () {
+      expect(driver.param('now()', 'timeuuid')).to.equal('now()');
+    });
+
+    it('does not remove the type hint from timeuuid values if the value is not a valid uuid', function () {
+      var param = driver.param('00000000-0000-0000-0000-000000000000', 'timeuuid');
+      expect(param.value).to.equal('00000000-0000-0000-0000-000000000000');
+      expect(param.hint).to.equal(cql.types.dataTypes.timeuuid);
+    });
+
+    it('removes the type hint from uuid values if the value is not a valid uuid', function () {
+      expect(driver.param('now()', 'uuid')).to.equal('now()');
+    });
+
+    it('does not remove the type hint from uuid values if the value is not a valid uuid', function () {
+      var param = driver.param('00000000-0000-0000-0000-000000000000', 'uuid');
+      expect(param.value).to.equal('00000000-0000-0000-0000-000000000000');
+      expect(param.hint).to.equal(cql.types.dataTypes.uuid);
+    });
+
     it('returns a hinted value wrapper if a type hint was provided', function () {
       var timestamp = new Date();
       var param = driver.param(timestamp, driver.dataType.timestamp);

--- a/test/unit/driver.basic.tests.js
+++ b/test/unit/driver.basic.tests.js
@@ -458,26 +458,6 @@ describe('lib/driver.js', function () {
       expect(driver.param('foo')).to.equal('foo');
     });
 
-    it('removes the type hint from timeuuid values if the value is not a valid uuid', function () {
-      expect(driver.param('now()', 'timeuuid')).to.equal('now()');
-    });
-
-    it('does not remove the type hint from timeuuid values if the value is not a valid uuid', function () {
-      var param = driver.param('00000000-0000-0000-0000-000000000000', 'timeuuid');
-      expect(param.value).to.equal('00000000-0000-0000-0000-000000000000');
-      expect(param.hint).to.equal(cql.types.dataTypes.timeuuid);
-    });
-
-    it('removes the type hint from uuid values if the value is not a valid uuid', function () {
-      expect(driver.param('now()', 'uuid')).to.equal('now()');
-    });
-
-    it('does not remove the type hint from uuid values if the value is not a valid uuid', function () {
-      var param = driver.param('00000000-0000-0000-0000-000000000000', 'uuid');
-      expect(param.value).to.equal('00000000-0000-0000-0000-000000000000');
-      expect(param.hint).to.equal(cql.types.dataTypes.uuid);
-    });
-
     it('returns a hinted value wrapper if a type hint was provided', function () {
       var timestamp = new Date();
       var param = driver.param(timestamp, driver.dataType.timestamp);

--- a/test/unit/driver.execution.tests.js
+++ b/test/unit/driver.execution.tests.js
@@ -778,37 +778,39 @@ describe('lib/driver.js', function () {
               { name: 'field1', types: [2, null] },
               { name: 'field2', types: [6, null] },
               { name: 'field3', types: [14, null] },
-              // Uuid types
+              // String types
               { name: 'field4', types: [12, null] },
               { name: 'field5', types: [15, null] },
+              { name: 'field6', types: [16, null] },
               // Map types
-              { name: 'field6', types: [33, null] },
               { name: 'field7', types: [33, null] },
               { name: 'field8', types: [33, null] },
               { name: 'field9', types: [33, null] },
               { name: 'field10', types: [33, null] },
+              { name: 'field11', types: [33, null] },
               // Set types
-              { name: 'field11', types: [34, null] },
               { name: 'field12', types: [34, null] },
               { name: 'field13', types: [34, null] },
               { name: 'field14', types: [34, null] },
-              { name: 'field15', types: [34, null] }
+              { name: 'field15', types: [34, null] },
+              { name: 'field16', types: [34, null] }
             ],
             field1: cql.types.Long.fromNumber(12345),
             field2: new cql.types.BigDecimal(12345, 2),
             field3: cql.types.Integer.fromNumber(54321),
             field4: cql.types.Uuid.random(),
             field5: cql.types.TimeUuid.now(),
-            field6: { nullKey: null, key: cql.types.Long.fromNumber(12345) },
-            field7: { nullKey: null, key: cql.types.Uuid.random() },
-            field8: { nullKey: null, key: 'value' },
-            field9: {},
-            field10: { nullKey: null },
-            field11: [null, cql.types.Long.fromNumber(12345)],
-            field12: [null, cql.types.Uuid.random()],
-            field13: [null, 'value'],
-            field14: [],
-            field15: [null]
+            field6: cql.types.InetAddress.fromString('127.0.0.1'),
+            field7: { nullKey: null, key: cql.types.Long.fromNumber(12345) },
+            field8: { nullKey: null, key: cql.types.Uuid.random() },
+            field9: { nullKey: null, key: 'value' },
+            field10: {},
+            field11: { nullKey: null },
+            field12: [null, cql.types.Long.fromNumber(12345)],
+            field13: [null, cql.types.Uuid.random()],
+            field14: [null, 'value'],
+            field15: [],
+            field16: [null]
           }
         ]
       };
@@ -827,16 +829,17 @@ describe('lib/driver.js', function () {
           field3: instance.dataType.varint,
           field4: instance.dataType.uuid,
           field5: instance.dataType.timeuuid,
-          field6: instance.dataType.map,
+          field6: instance.dataType.inet,
           field7: instance.dataType.map,
           field8: instance.dataType.map,
           field9: instance.dataType.map,
           field10: instance.dataType.map,
-          field11: instance.dataType.set,
+          field11: instance.dataType.map,
           field12: instance.dataType.set,
           field13: instance.dataType.set,
           field14: instance.dataType.set,
-          field15: instance.dataType.set
+          field15: instance.dataType.set,
+          field16: instance.dataType.set
         }
       }, function (error, returnData) {
         if (error) { return void done(error); }
@@ -857,34 +860,36 @@ describe('lib/driver.js', function () {
           assert.strictEqual(record.field4, data.rows[0].field4.toString(), 'fourth field value should match');
           assert.strictEqual(typeof record.field5, 'string', 'fifth field should be a string');
           assert.strictEqual(record.field5, data.rows[0].field5.toString(), 'fifth field value should match');
+          assert.strictEqual(typeof record.field6, 'string', 'sixth field should be a string');
+          assert.strictEqual(record.field6, data.rows[0].field6.toString(), 'sixth field value should match');
 
           // Maps
-          assert.strictEqual(typeof record.field6.key, 'number', 'sixth field key value should be a number');
-          assert.strictEqual(record.field6.key, 12345, 'sixth field key value should match');
-          assert.isNull(record.field6.nullKey, 'sixth field nullkey should be null');
-          assert.strictEqual(typeof record.field7.key, 'string', 'seventh field key value should be a string');
-          assert.strictEqual(record.field7.key, data.rows[0].field7.key.toString(), 'seventh field key value should match');
+          assert.strictEqual(typeof record.field7.key, 'number', 'seventh field key value should be a number');
+          assert.strictEqual(record.field7.key, 12345, 'seventh field key value should match');
           assert.isNull(record.field7.nullKey, 'seventh field nullkey should be null');
           assert.strictEqual(typeof record.field8.key, 'string', 'eighth field key value should be a string');
-          assert.strictEqual(record.field8.key, 'value', 'eighth field key value should match');
+          assert.strictEqual(record.field8.key, data.rows[0].field8.key.toString(), 'eighth field key value should match');
           assert.isNull(record.field8.nullKey, 'eighth field nullkey should be null');
-          assert.isTrue(Object.keys(record.field9).length === 0, 'ninth field should be an empty object');
-          assert.isTrue(Object.keys(record.field10).length === 1, 'tenth field should contain only nullKey');
-          assert.isNull(record.field10.nullKey, 'tenth field nullkey should be null');
+          assert.strictEqual(typeof record.field9.key, 'string', 'ninth field key value should be a string');
+          assert.strictEqual(record.field9.key, 'value', 'ninth field key value should match');
+          assert.isNull(record.field9.nullKey, 'ninth field nullkey should be null');
+          assert.isTrue(Object.keys(record.field10).length === 0, 'tenth field should be an empty object');
+          assert.isTrue(Object.keys(record.field11).length === 1, 'eleventh field should contain only nullKey');
+          assert.isNull(record.field11.nullKey, 'eleventh field nullkey should be null');
 
           // Sets
-          assert.isNull(record.field11[0], 'eleventh field null index should be null');
-          assert.strictEqual(typeof record.field11[1], 'number', 'eleventh field index value should be a number');
-          assert.strictEqual(record.field11[1], 12345, 'eleventh field index value should match');
           assert.isNull(record.field12[0], 'twelfth field null index should be null');
-          assert.strictEqual(typeof record.field12[1], 'string', 'twelfth field index value should be a string');
-          assert.strictEqual(record.field12[1], data.rows[0].field12[1].toString(), 'twelfth field index value should match');
+          assert.strictEqual(typeof record.field12[1], 'number', 'twelfth field index value should be a number');
+          assert.strictEqual(record.field12[1], 12345, 'twelfth field index value should match');
           assert.isNull(record.field13[0], 'thirteenth field null index should be null');
           assert.strictEqual(typeof record.field13[1], 'string', 'thirteenth field index value should be a string');
-          assert.strictEqual(record.field13[1], 'value', 'thirteenth field index value should match');
-          assert.isTrue(record.field14.length === 0, 'fourteenth field should be an empty array');
-          assert.isTrue(record.field15.length === 1, 'fifteenth field should contain only null');
-          assert.isNull(record.field15[0], 'fifteenth field null index should be null');
+          assert.strictEqual(record.field13[1], data.rows[0].field13[1].toString(), 'thirteenth field index value should match');
+          assert.isNull(record.field14[0], 'thirteenth field null index should be null');
+          assert.strictEqual(typeof record.field14[1], 'string', 'fourteenth field index value should be a string');
+          assert.strictEqual(record.field14[1], 'value', 'fourteenth field index value should match');
+          assert.isTrue(record.field15.length === 0, 'fifteenth field should be an empty array');
+          assert.isTrue(record.field16.length === 1, 'sixteenth field should contain only null');
+          assert.isNull(record.field16[0], 'sixteenth field null index should be null');
         }
         else {
           assert.isTrue(record.field1 instanceof cql.types.Long, 'first field should not be transformed');
@@ -892,16 +897,17 @@ describe('lib/driver.js', function () {
           assert.isTrue(record.field3 instanceof cql.types.Integer, 'third field should not be transformed');
           assert.isTrue(record.field4 instanceof cql.types.Uuid, 'fourth field should not be transformed');
           assert.isTrue(record.field5 instanceof cql.types.TimeUuid, 'fifth field should not be transformed');
-          assert.isTrue(record.field6.key instanceof cql.types.Long, 'sixth field key value should not be transformed');
-          assert.isTrue(record.field7.key instanceof cql.types.Uuid, 'seventh field key value should not be transformed');
-          assert.isTrue(typeof record.field8.key === 'string', 'eighth field key value should not be transformed');
-          assert.isTrue(Object.keys(record.field9).length === 0, 'ninth field should be an empty object');
-          assert.isTrue(Object.keys(record.field10).length === 1, 'tenth field should contain only nullKey');
-          assert.isTrue(record.field11[1] instanceof cql.types.Long, 'eleventh field index value should not be transformed');
-          assert.isTrue(record.field12[1] instanceof cql.types.Uuid, 'twelfth field index value should not be transformed');
-          assert.isTrue(typeof record.field13[1] === 'string', 'thirteenth field index value should not be transformed');
-          assert.isTrue(record.field14.length === 0, 'fourteenth field should be an empty array');
-          assert.isTrue(record.field15.length === 1, 'fifteenth field should not be transformed');
+          assert.isTrue(record.field6 instanceof cql.types.InetAddress, 'sixth field should not be transformed');
+          assert.isTrue(record.field7.key instanceof cql.types.Long, 'seventh field key value should not be transformed');
+          assert.isTrue(record.field8.key instanceof cql.types.Uuid, 'eighth field key value should not be transformed');
+          assert.isTrue(typeof record.field9.key === 'string', 'ninth field key value should not be transformed');
+          assert.isTrue(Object.keys(record.field10).length === 0, 'tenth field should be an empty object');
+          assert.isTrue(Object.keys(record.field11).length === 1, 'eleventh field should contain only nullKey');
+          assert.isTrue(record.field12[1] instanceof cql.types.Long, 'twelfth field index value should not be transformed');
+          assert.isTrue(record.field13[1] instanceof cql.types.Uuid, 'thirteenth field index value should not be transformed');
+          assert.isTrue(typeof record.field14[1] === 'string', 'fourteenth field index value should not be transformed');
+          assert.isTrue(record.field15.length === 0, 'fifteenth field should be an empty array');
+          assert.isTrue(record.field16.length === 1, 'sixteenth field should not be transformed');
         }
 
         done();


### PR DESCRIPTION
Update to the latest `cassandra-driver@2.2.0`. We've been using this branch in production for almost a month now without any problems.