### PR TITLE
Allow specification of local DC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 2.2.0
+
+New features:
+
+* Support a `localDataCenter` config setting to use in the load balancing policy

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ var db = require('priam')({
       '123.456.789.011:9042',
       '123.456.789.012:9042',
       '123.456.789.013:9042'
-    ]
+    ],
+    localDataCenter: 'some_dc' /* optional; used for selecting preferred nodes during load balancing */ 
   }
 });
 ```
@@ -519,7 +520,7 @@ var resolver = new MyConnectionResolver();
 var db = require('priam')({
   config: {
     /* ... connection options ... */
-  }
+  },
   connectionResolver: resolver
 });
 ```

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -1,5 +1,3 @@
-
-
 var EventEmitter = require('events').EventEmitter;
 var _ = require('lodash');
 var async = require('async');
@@ -79,10 +77,24 @@ DatastaxDriver.prototype.init = function init(context) {
 
   this.initProviderOptions(this.config);
   this.keyspace = context.config.keyspace;
+  this.initPoolConfig();
+  this.initConnectionResolver(context);
+
+  this.pools = {};
+  this.resultTransformers = context.resultTransformers || [];
+};
+
+DatastaxDriver.prototype.initProviderOptions = function init(config) {
+  setHelenusOptions(config);
+  config.supportsPreparedStatements = true;
+};
+
+DatastaxDriver.prototype.initPoolConfig = function () {
   this.poolConfig = {
     consistencyLevel: this.consistencyLevel.one
   };
   this.poolConfig = _.extend(this.poolConfig, this.config);
+
   if (typeof this.config.consistency === 'string') {
     var level = this.config.consistency;
 
@@ -93,6 +105,17 @@ DatastaxDriver.prototype.init = function init(context) {
     }
   }
 
+  if (typeof this.config.localDataCenter === 'string') {
+    this.poolConfig.policies = this.poolConfig.policies || {};
+    if (!this.poolConfig.policies.loadBalancing) {
+      this.poolConfig.policies.loadBalancing = new cqlDriver.policies.loadBalancing.TokenAwarePolicy(
+        new cqlDriver.policies.loadBalancing.DCAwareRoundRobinPolicy(this.config.localDataCenter)
+      );
+    }
+  }
+};
+
+DatastaxDriver.prototype.initConnectionResolver = function (context) {
   this.connectionResolver = null;
   if (context.connectionResolver) {
     this.connectionResolver = context.connectionResolver;
@@ -109,14 +132,6 @@ DatastaxDriver.prototype.init = function init(context) {
       this.connectionResolver.on('lazyfetch', this.connectionResolverFetchHandler.bind(this));
     }
   }
-
-  this.pools = {};
-  this.resultTransformers = context.resultTransformers || [];
-};
-
-DatastaxDriver.prototype.initProviderOptions = function init(config) {
-  setHelenusOptions(config);
-  config.supportsPreparedStatements = true;
 };
 
 DatastaxDriver.prototype.getConnectionPool = function getConnectionPool(keyspace, waitForConnect, callback) {

--- a/test/unit/.eslintrc
+++ b/test/unit/.eslintrc
@@ -3,6 +3,7 @@
   "rules": {
     "no-new": "off",
     "max-nested-callbacks": "off",
-    "handle-callback-err": "warn"
+    "handle-callback-err": "warn",
+    "max-statements": "off"
   }
 }


### PR DESCRIPTION
* Add configurable local DC for the load balancing policy

The `cassandra-driver` library has been emitting these warnings for a while:

> priam.Driver.Client: No local Data Center was provided with DCAwareRoundRobinPolicy. Using discovered DC 'xxxxx' from host yyyyy. Future releases will require local DC to be specified.

This is occurring because the default load balancing policy is:

```js
new TokenAwarePolicy(new DCAwareRoundRobinPolicy())
```

This `DCAwareRoundRobinPolicy` is instantiated without a local DC specified, so it's unable to know which of the hosts it connects to are considered part of the local DC. To fix this, we'll construct the same load balancing policy as the default with a DC specified, if so configured.