### PR TITLE
Update cassandra-driver, major version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.0.0
+
+New features:
+
+* `localDataCenter` is now a required field in `cassandra-driver` version 4.
+
 ## 2.2.0
 
 New features:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ var db = require('priam')({
       '123.456.789.012:9042',
       '123.456.789.013:9042'
     ],
-    localDataCenter: 'some_dc' /* optional; used for selecting preferred nodes during load balancing */ 
+    localDataCenter: 'some_dc' /* required; used for selecting preferred nodes during load balancing */ 
   }
 });
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "priam",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -346,9 +346,9 @@
       "dev": true
     },
     "cassandra-driver": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/cassandra-driver/-/cassandra-driver-3.6.0.tgz",
-      "integrity": "sha512-CkN3V+oPaF5RvakUjD3uUjEm8f6U8S0aT1+YqeQsVT3UDpPT2K8SOdNDEHA1KjamakHch6zkDgHph1xWyqBGGw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cassandra-driver/-/cassandra-driver-4.1.0.tgz",
+      "integrity": "sha512-MHI8PcCCaPEa9DKsP+L6MsokrK5Twhu4UBb3reyEAezB0XFhu7DnjDcfWuDHpzmuCY3OSmgskO1pnoz1GsRIIA==",
       "requires": {
         "long": "^2.2.0"
       }
@@ -1698,9 +1698,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "priam",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "A simple Cassandra driver. It wraps cassandra-driver modules with additional error/retry handling, external .cql file support, connection option resolution from an external source, and query composition, among other improvements.",
   "keywords": [
     "cassandra",
@@ -23,9 +23,9 @@
   ],
   "dependencies": {
     "async": "^1.2.1",
-    "cassandra-driver": "^3.0.2",
+    "cassandra-driver": "^4.1.0",
     "isstream": "^0.1.2",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "q": "^1.4.1",
     "read-only-stream": "^1.1.1",
     "retry": "^0.6.1",


### PR DESCRIPTION
Upgrade to the latest `cassandra-driver`, moving from `^3.0.0` to `^4.0.0`. The breaking change here affects the constructor (`localDataCenter` is now a required property), so `priam` also requires a major version bump.