### PR TITLE
Add additional metadata to error objects

### DIFF
--- a/lib/driver.js
+++ b/lib/driver.js
@@ -405,6 +405,11 @@ DatastaxDriver.prototype.executeCqlOnDriver = function executeCqlOnDriver(pool, 
       if (err instanceof cqlDriver.errors.ResponseError) {
         err.type = findResponseErrorType(err.code);
       }
+      err.query = {
+        cql: cqlStatement,
+        params: params,
+        options: execOptions
+      };
       return void callback(err);
     }
     var result = (data && data.rows) ? data.rows : [];
@@ -418,9 +423,23 @@ DatastaxDriver.prototype.streamCqlOnDriver = function streamCqlOnDriver(pool, cq
   cqlStatement = opts.cqlStatement;
   params = opts.params;
   pool.stream(cqlStatement, params, execOptions)
-    .on('error', stream.emit.bind(stream, 'error'))
+    .on('error', err => {
+      err.query = {
+        cql: cqlStatement,
+        params: params,
+        options: execOptions
+      };
+      stream.emit('error', err);
+    })
     .pipe(this.getResultTransformStream(execOptions))
-    .on('error', stream.emit.bind(stream, 'error'))
+    .on('error', err => {
+      err.query = {
+        cql: cqlStatement,
+        params: params,
+        options: execOptions
+      };
+      stream.emit('error', err);
+    })
     .pipe(stream);
 };
 
@@ -513,6 +532,11 @@ DatastaxDriver.prototype.namedQuery = function namedQuery(name, dataParams, opti
 
   self.queryCache.readQuery(name, function (err, queryText) {
     if (err) {
+      err.query = {
+        queryName: name,
+        params: dataParams,
+        options: options
+      };
       return void callback(err);
     }
     options.queryName = options.queryName || name;

--- a/test/unit/driver.execution.tests.js
+++ b/test/unit/driver.execution.tests.js
@@ -1088,6 +1088,15 @@ describe('lib/driver.js', function () {
             assert.deepEqual(returnData, data, 'data should match cql output');
           } else {
             assert.strictEqual(pool.execute.callCount, 1, 'execute should be called once');
+            assert.instanceOf(error, Error, 'error is not populated');
+            assert.isObject(error.query, 'query is not defined');
+            assert.equal(error.query.cql, cqlQuery, 'query.cql does not match query');
+            assert.instanceOf(error.query.params, Array, 'query.params is not an array');
+            assert.deepEqual(error.query.options, {
+              consistency: consistency,
+              prepare: false
+            }, 'query.options does not match query options');
+            assert.isUndefined(returnData, 'returnData not defined');
           }
 
           done();
@@ -1867,7 +1876,7 @@ describe('lib/driver.js', function () {
     });
 
     function validateQueryCalls(asPromise) {
-      it('#execute() executes cq ' +
+      it('#execute() executes cql ' +
         (asPromise ? 'with promise syntax' : 'with callback syntax'),
       function (done) {
         // arrange
@@ -2000,6 +2009,8 @@ describe('lib/driver.js', function () {
       instance.namedQuery(queryName, [], function (error, returnData) {
         // assert
         assert.instanceOf(error, Error, 'error is populated');
+        assert.isObject(error.query, 'query is not defined');
+        assert.equal(error.query.queryName, 'idontexist', 'query.queryName does not match named query');
         assert.isUndefined(returnData, 'returnData not defined');
 
         done();


### PR DESCRIPTION
When errors occur, it would be helpful to know the CQL and options used when the error was generated.