### PR TITLE
Update minimum Node version to 10.17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '10'
+  - '10.17'
   - '12'
   - '13'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 This major release is geared toward internal performance improvements and removing some legacy code cruft relating to the now-defunct dual driver support.
 
 **BREAKING**:
-* Priam now requires node 10 or node 12 or greater so it can take advantage of async iterator support. For some reason, node 11 is incompatible.
+* Priam now requires node 10.17 or node 12 or greater so it can take advantage of async iterator support. For some reason, node 11 is incompatible.
 * In olden days, `priam` supported two underlying Cassandra drivers. This is no-longer the case, so some effort has been done to remove the cruft in the code for this dual support. One of these changes removes the translation of the old `helenus` driver config options to those compatible with `cassandra-driver`. Config options in `priam` are now aligned directly with the config options of `cassandra-driver`.
 * Errors are now emitted correctly when writing to a stream. This means you may now need to attach `error` handlers to your streams to avoid unhandled error exceptions.
 * Undocumented private methods have now been prefixed with underscores; if your code was calling these undocumented methods directly, those methods may now have been renamed or removed.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,7 +4,7 @@
 
 ### Node Requirements
 
-This version of `priam` requires node 10 or above (but not version 11 which has a strange compatibility break).
+This version of `priam` requires node 10.17 or above (but not version 11 which has a strange compatibility break).
 
 ### Config Setting Updates
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "email": "scommisso@godaddy.com"
   },
   "engines": {
-    "node": "^10.0.0 || >=12.0.0"
+    "node": "^10.17.0 || >=12.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Changes to the streaming interface that are relied upon by the new codebase requires, at minimum, Node 10.17.0. (verified by testing Node 10.15.3 through Node 10.17 while running unit tests).